### PR TITLE
Ignore descriptive annotations during inversion

### DIFF
--- a/fences/json_schema/normalize.py
+++ b/fences/json_schema/normalize.py
@@ -71,7 +71,11 @@ _inverters = {
     #'required': lambda x: {'type': ['object']},
     'items': _invert_items,
     'minItems': lambda x: {'type': 'array', 'maxItems': x},
-    'pattern': lambda x: {'type': 'string', 'pattern': f"!({x})"}
+    'pattern': lambda x: {'type': 'string', 'pattern': f"!({x})"},
+    # Ignore descriptive annotations
+    'description': lambda x: {},
+    'title': lambda x: {},
+    '$comment': lambda x: {},
 }
 
 


### PR DESCRIPTION
Some keywords such as `title` do not have any impact on validation, so don't have a meaningful inverse.
This skips some of these keywords during inversion.
